### PR TITLE
Update 04_While_Loops.md

### DIFF
--- a/English/04_While_Loops.md
+++ b/English/04_While_Loops.md
@@ -197,7 +197,7 @@ while rounds < 100000:
     while (dice1!=6 or dice2!=6):
         dice1 = random.randint(1,6)
         dice2 = random.randint(1,6)
-	rolls = rolls + 1
+		rolls = rolls + 1
     #print(f"Rolled {rolls:d} times.")
     rounds = rounds + 1
     total_rolls = total_rolls + rolls
@@ -331,3 +331,4 @@ the stop button on the side of the console window:
 
 If the stop button does not stop the execution, check that the terminal emulation operations are enabled in
 the console window: select **Run/Edit Configurations** and check the **Emulate Terminal in Output Console** checkbox.
+


### PR DESCRIPTION
The original code had an indentation issue where the 'rolls' counter was not properly incremented inside the dice rolling loop.

This caused the program to not track the number of rolls correctly.

The indentation has been fixed, ensuring the 'rolls' counter is incremented each time the dice are rolled, so the total number of rolls per round is correctly calculated.